### PR TITLE
Update BasemapGallery.Appearance.cs OnApplyTemplate()

### DIFF
--- a/src/Toolkit/Toolkit.UI.Controls/BasemapGallery/BasemapGallery.Appearance.cs
+++ b/src/Toolkit/Toolkit.UI.Controls/BasemapGallery/BasemapGallery.Appearance.cs
@@ -54,6 +54,12 @@ namespace Esri.ArcGISRuntime.Toolkit.UI.Controls
             ListView = GetTemplateChild("PART_InnerListView") as ListView;
             _loadingScrim = GetTemplateChild("PART_LoadingScrim") as UIElement;
 
+            if (AvailableBasemaps.Count != 0)
+            {
+                _loadingScrim.Visibility = Visibility.Collapsed;
+                ListView.ItemsSource = AvailableBasemaps;
+            }
+
             SetNewStyle(ActualWidth);
         }
 


### PR DESCRIPTION
With this modification, you can start BasemapGallery Collapsed and later change it to Visible work under .NetFramework 472.   This change won't break .NET 6 side.   Currently if you start BasemapGallery collapsed, you can never see loaded basemap list due to the fact that _loadingScrim never goes away under .Netframework 472.